### PR TITLE
Update test for loading indicator

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import axios from 'axios';
 
-test('renders learn react link', () => {
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+}));
+
+test('shows initial loading indicator', async () => {
+  axios.get.mockResolvedValue({ data: { isGameStarted: false, teams: [], loggedInTeams: [] } });
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/loading/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- replace CRA default test in `App.test.js`
- assert initial loading indicator appears on render
- mock axios so tests run under Jest

## Testing
- `CI=true npm test --silent --color=always </dev/null`

------
https://chatgpt.com/codex/tasks/task_e_683f591341388330a4b35c70bea49757